### PR TITLE
BUMP pyproject.toml - bump package version to 0.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pact-methodology"
-version = "0.0.1"
+version = "0.0.2"
 description = ""
 authors = ["JohnVonNeumann <louis@zerotwentyfifty.com>"]
 readme = "README.md"


### PR DESCRIPTION
bump the pyproject package to version 0.0.2 to reflect completion of the 2.2.0 functionality